### PR TITLE
Unbreak build with libc++

### DIFF
--- a/src/nuspell/locale_utils.hxx
+++ b/src/nuspell/locale_utils.hxx
@@ -24,11 +24,11 @@
 #ifndef LOCALE_UTILS_HXX
 #define LOCALE_UTILS_HXX
 
-#include <boost/locale/encoding_utf.hpp>
-#include <boost/locale/info.hpp>
 #include <locale>
 #include <string>
 #include <type_traits>
+#include <boost/locale/encoding_utf.hpp>
+#include <boost/locale/info.hpp>
 
 namespace nuspell {
 


### PR DESCRIPTION
libstdc++ pulls `<string>` via `<stdexcept>`, libc++ doesn't. macOS, FreeBSD, OpenBSD use libc++.
```
In file included from /usr/local/lib/gcc7/include/c++/stdexcept:39:0,
                 from /usr/local/include/boost/locale/encoding_errors.hpp:16,
                 from /usr/local/include/boost/locale/encoding_utf.hpp:12,
                 from locale_utils.hxx:27,
                 from locale_utils.cxx:24:
/usr/local/lib/gcc7/include/c++/string:36:2: error: #error bootlegging test
```
 I'm using Boost 1.67.0 if that matters.