### PR TITLE
Get rid of wget dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/catch"]
+	path = third_party/catch
+	url = https://github.com/catchorg/Catch2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Main features of Nuspell spell checker and morphological analyzer:
 
 Build only dependencies:
 
-    g++ make autoconf automake libtool wget
+    g++ make autoconf automake libtool
 
 Runtime dependencies:
 
@@ -107,7 +107,7 @@ Homebrew and rebuild all the dependencies with it. See Homewbrew manuals.
 
 Install the required development packages with
 
-    sudo pkg install -y bash autoconf automake libtool libiconv icu gcc wget \
+    sudo pkg install -y bash autoconf automake libtool libiconv icu gcc \
                         boost-libs
 
 Then run the standard trio of autoreconf, configure and make. See above.

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,8 @@ AM_ICONV
 BOOST_REQUIRE([1.62.0])
 BOOST_LOCALE
 PKG_CHECK_MODULES([ICU], [icu-uc])
+PKG_CHECK_MODULES([CATCH], [catch],,
+	[CATCH_CFLAGS="-I../third_party/catch/single_include"])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 
 # Checks for header files.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,20 +1,10 @@
 SUBDIRS = . suggestiontest v1cmdline
 
-AM_CPPFLAGS = -I../src/nuspell $(BOOST_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)
+AM_CPPFLAGS = -I../src/nuspell $(BOOST_CPPFLAGS) $(CATCH_CFLAGS) $(CODE_COVERAGE_CPPFLAGS)
 AM_CXXFLAGS = -std=c++14 $(CODE_COVERAGE_CXXFLAGS)
 AM_LDFLAGS  = $(BOOST_LOCALE_LDFLAGS)
 LDADD = ../src/nuspell/libnuspell.a $(BOOST_LOCALE_LIBS) $(CODE_COVERAGE_LIBS) $(ICU_LIBS)
 
-
-BUILT_SOURCES = catch.hpp catch_reporter_tap.hpp
-catch_url = https://raw.githubusercontent.com/catchorg/Catch2/v2.2.2
-catch.hpp:
-	wget $(catch_url)/single_include/catch.hpp
-
-catch_reporter_tap.hpp:
-	wget $(catch_url)/single_include/catch_reporter_tap.hpp
-
-CLEANFILES = catch.hpp catch_reporter_tap.hpp
 
 TEST_EXTENSIONS = .catch
 CATCH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
@@ -36,9 +26,6 @@ structures_test.cxx \
 dictionary_test.cxx \
 aff_data_test.cxx \
 catch_main.cxx
-
-nodist_ch_catch_SOURCES = catch.hpp catch_reporter_tap.hpp
-
 
 # to run coverage, cd to root
 # ./configure --enable-code-coverage


### PR DESCRIPTION
Downstream may not allow network activity during build to facilitate reproducibility/mirroring. And [some](https://repology.org/metapackage/catch/versions) [distributions](https://repology.org/metapackage/catch2/versions) can use system  Catch.